### PR TITLE
merge :: (#13) 구글 OAuth 코드 교환 로그인 API 추가

### DIFF
--- a/api-spec.json
+++ b/api-spec.json
@@ -154,6 +154,59 @@
           "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
           "deleted": true
         }
+      },
+      "GoogleCodeLoginBody": {
+        "type": "object",
+        "required": ["code", "redirectUri"],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Google authorization code received by the client"
+          },
+          "redirectUri": {
+            "type": "string",
+            "format": "uri",
+            "description": "Redirect URI used when requesting the authorization code"
+          },
+          "codeVerifier": {
+            "type": "string",
+            "minLength": 43,
+            "maxLength": 128,
+            "description": "PKCE code verifier when the client uses PKCE"
+          }
+        },
+        "example": {
+          "code": "4/0AQSTgQExampleAuthCode",
+          "redirectUri": "http://localhost:5173/auth/google/callback",
+          "codeVerifier": "0123456789012345678901234567890123456789012"
+        }
+      },
+      "AuthUserResponse": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "email": { "type": "string", "format": "email" },
+          "provider": { "type": "string", "enum": ["GOOGLE", "APPLE", "KAKAO"] },
+          "nickname": { "type": "string" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "OAuthLoginResponse": {
+        "type": "object",
+        "properties": {
+          "accessToken": { "type": "string" },
+          "user": { "$ref": "#/components/schemas/AuthUserResponse" }
+        },
+        "example": {
+          "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+          "user": {
+            "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "email": "spotlog@example.com",
+            "provider": "GOOGLE",
+            "nickname": "SpotLog",
+            "createdAt": "2026-04-24T00:00:00.000Z"
+          }
+        }
       }
     }
   },
@@ -188,6 +241,34 @@
               }
             }
           }
+        }
+      }
+    },
+    "/auth/google/code": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Google authorization code login",
+        "description": "Exchanges the client-provided Google authorization code on the server, loads the Google profile, creates or finds the user, and returns the service JWT.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/GoogleCodeLoginBody" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "JWT access token and authenticated user",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OAuthLoginResponse" }
+              }
+            }
+          },
+          "400": { "description": "Invalid request body" },
+          "401": { "description": "Invalid Google authorization code or Google account information" },
+          "502": { "description": "Failed to exchange the code or load the Google profile from Google APIs" }
         }
       }
     },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'ts'],
+  preset: 'ts-jest',
+  rootDir: '.',
+  testEnvironment: 'node',
+  testRegex: '.*\\.spec\\.ts$',
+  transform: {
+    '^.+\\.(t|j)s$': 'ts-jest'
+  }
+};

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,10 +1,16 @@
-﻿import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Req, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { AuthService } from './auth.service';
+import { GoogleCodeLoginDto } from './dto/google-code-login.dto';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
+
+  @Post('google/code')
+  loginWithGoogleCode(@Body() body: GoogleCodeLoginDto) {
+    return this.authService.loginWithGoogleCode(body);
+  }
 
   @Get('google')
   @UseGuards(AuthGuard('google'))

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,162 @@
+import {
+  BadGatewayException,
+  InternalServerErrorException,
+  UnauthorizedException
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { AuthProvider } from '../users/user.entity';
+import { AuthService } from './auth.service';
+
+describe('AuthService', () => {
+  const usersService = {
+    findByProvider: jest.fn(),
+    createFromOAuth: jest.fn()
+  };
+  const jwtService = {
+    signAsync: jest.fn()
+  };
+  const configService = {
+    get: jest.fn()
+  } as unknown as ConfigService;
+
+  let authService: AuthService;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authService = new AuthService(
+      usersService as any,
+      jwtService as unknown as JwtService,
+      configService
+    );
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as typeof fetch;
+
+    usersService.findByProvider.mockResolvedValue({
+      id: 'user-id',
+      email: 'spotlog@example.com',
+      provider: AuthProvider.GOOGLE,
+      nickname: 'SpotLog',
+      createdAt: new Date('2026-04-24T00:00:00.000Z')
+    });
+    jwtService.signAsync.mockResolvedValue('signed-jwt');
+    (configService.get as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'GOOGLE_CLIENT_ID') {
+        return 'google-client-id';
+      }
+      if (key === 'GOOGLE_CLIENT_SECRET') {
+        return 'google-client-secret';
+      }
+      if (key === 'JWT_EXPIRES_IN') {
+        return '15m';
+      }
+      return undefined;
+    });
+  });
+
+  afterEach(() => {
+    delete (global as Partial<typeof globalThis>).fetch;
+  });
+
+  it('exchanges a Google code and returns the service JWT payload', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'google-access-token'
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          sub: 'google-user-id',
+          email: 'spotlog@example.com',
+          email_verified: true,
+          name: 'SpotLog'
+        })
+      });
+
+    const result = await authService.loginWithGoogleCode({
+      code: 'google-auth-code',
+      redirectUri: 'http://localhost:5173',
+      codeVerifier: '0123456789012345678901234567890123456789012'
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://oauth2.googleapis.com/token',
+      expect.objectContaining({
+        method: 'POST'
+      })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://openidconnect.googleapis.com/v1/userinfo',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer google-access-token'
+        }
+      })
+    );
+    expect(usersService.findByProvider).toHaveBeenCalledWith(
+      AuthProvider.GOOGLE,
+      'google-user-id'
+    );
+    expect(result).toEqual({
+      accessToken: 'signed-jwt',
+      user: {
+        id: 'user-id',
+        email: 'spotlog@example.com',
+        provider: AuthProvider.GOOGLE,
+        nickname: 'SpotLog',
+        createdAt: new Date('2026-04-24T00:00:00.000Z')
+      }
+    });
+  });
+
+  it('throws unauthorized when Google rejects the code', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({
+        error: 'invalid_grant'
+      })
+    });
+
+    await expect(
+      authService.loginWithGoogleCode({
+        code: 'bad-code',
+        redirectUri: 'http://localhost:5173'
+      })
+    ).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it('throws when Google OAuth credentials are missing', async () => {
+    (configService.get as jest.Mock).mockReturnValue(undefined);
+
+    await expect(
+      authService.loginWithGoogleCode({
+        code: 'google-auth-code',
+        redirectUri: 'http://localhost:5173'
+      })
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+
+  it('throws bad gateway when Google userinfo cannot be reached', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          access_token: 'google-access-token'
+        })
+      })
+      .mockRejectedValueOnce(new Error('network error'));
+
+    await expect(
+      authService.loginWithGoogleCode({
+        code: 'google-auth-code',
+        redirectUri: 'http://localhost:5173'
+      })
+    ).rejects.toBeInstanceOf(BadGatewayException);
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,14 +1,33 @@
-﻿import { Injectable } from '@nestjs/common';
-import { JwtService } from '@nestjs/jwt';
+import {
+  BadGatewayException,
+  Injectable,
+  InternalServerErrorException,
+  UnauthorizedException
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { UsersService } from '../users/users.service';
 import { AuthProvider } from '../users/user.entity';
+import { GoogleCodeLoginDto } from './dto/google-code-login.dto';
 
 export type OAuthProfile = {
   provider: AuthProvider;
   providerUserId: string;
   email: string;
   nickname: string;
+};
+
+type GoogleTokenResponse = {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+};
+
+type GoogleUserInfoResponse = {
+  sub?: string;
+  email?: string;
+  email_verified?: boolean;
+  name?: string;
 };
 
 @Injectable()
@@ -22,6 +41,13 @@ export class AuthService {
   private signAccessToken(userId: string) {
     const expiresIn = this.configService.get<string>('JWT_EXPIRES_IN') || '15m';
     return this.jwtService.signAsync({ sub: userId }, { expiresIn });
+  }
+
+  async loginWithGoogleCode(body: GoogleCodeLoginDto) {
+    const accessToken = await this.exchangeGoogleCodeForAccessToken(body);
+    const profile = await this.fetchGoogleProfile(accessToken);
+
+    return this.loginOAuth(profile);
   }
 
   async loginOAuth(profile: OAuthProfile) {
@@ -45,6 +71,88 @@ export class AuthService {
         nickname: user.nickname,
         createdAt: user.createdAt
       }
+    };
+  }
+
+  private async exchangeGoogleCodeForAccessToken({
+    code,
+    redirectUri,
+    codeVerifier
+  }: GoogleCodeLoginDto) {
+    const clientId = this.configService.get<string>('GOOGLE_CLIENT_ID');
+    const clientSecret = this.configService.get<string>('GOOGLE_CLIENT_SECRET');
+
+    if (!clientId || !clientSecret) {
+      throw new InternalServerErrorException('Google OAuth is not configured.');
+    }
+
+    const payload = new URLSearchParams({
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri
+    });
+
+    if (codeVerifier) {
+      payload.set('code_verifier', codeVerifier);
+    }
+
+    let response: Response;
+    try {
+      response = await fetch('https://oauth2.googleapis.com/token', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: payload
+      });
+    } catch {
+      throw new BadGatewayException('Failed to reach Google token endpoint.');
+    }
+
+    const data = (await response.json()) as GoogleTokenResponse;
+
+    if (!response.ok || !data.access_token) {
+      if (data.error === 'invalid_grant' || data.error === 'redirect_uri_mismatch') {
+        throw new UnauthorizedException('Invalid Google authorization code.');
+      }
+
+      throw new BadGatewayException(
+        data.error_description || 'Google token exchange failed.'
+      );
+    }
+
+    return data.access_token;
+  }
+
+  private async fetchGoogleProfile(accessToken: string): Promise<OAuthProfile> {
+    let response: Response;
+    try {
+      response = await fetch('https://openidconnect.googleapis.com/v1/userinfo', {
+        headers: {
+          Authorization: `Bearer ${accessToken}`
+        }
+      });
+    } catch {
+      throw new BadGatewayException('Failed to reach Google userinfo endpoint.');
+    }
+
+    const data = (await response.json()) as GoogleUserInfoResponse;
+
+    if (!response.ok) {
+      throw new UnauthorizedException('Failed to load Google user profile.');
+    }
+
+    if (!data.sub || !data.email || !data.email_verified) {
+      throw new UnauthorizedException('Google account information is invalid.');
+    }
+
+    return {
+      provider: AuthProvider.GOOGLE,
+      providerUserId: data.sub,
+      email: data.email,
+      nickname: data.name || data.email.split('@')[0] || 'user'
     };
   }
 }

--- a/src/auth/dto/google-code-login.dto.ts
+++ b/src/auth/dto/google-code-login.dto.ts
@@ -1,0 +1,19 @@
+import { IsOptional, IsString, IsUrl, MaxLength, MinLength } from 'class-validator';
+
+export class GoogleCodeLoginDto {
+  @IsString()
+  @MinLength(1)
+  code!: string;
+
+  @IsUrl({
+    require_tld: false,
+    require_protocol: true
+  })
+  redirectUri!: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(43)
+  @MaxLength(128)
+  codeVerifier?: string;
+}


### PR DESCRIPTION
## 작업 내용 설명
- [x] 클라이언트가 전달한 Google authorization code를 서버에서 교환하는 `POST /auth/google/code` 로그인 API를 추가했습니다.
- [x] Google token exchange, userinfo 조회, 회원 조회/생성, 서비스 JWT 발급 흐름을 구현했습니다.
- [x] `api-spec.json`에 요청/응답 스키마와 `POST /auth/google/code` 경로를 추가했습니다.
- [x] AuthService 단위 테스트를 추가했습니다.

## 결과물 있으면
- Swagger/OpenAPI 문서에 `POST /auth/google/code` 경로가 반영되었습니다.

## 체크리스트
- [x] 애플리케이션 구동 여부 또는 관련 검증 수행
- [ ] DDL 변경 시 Flyway 필요 여부
- [x] 테스트 코드 추가 여부

## 관련 이슈
- resolved #13